### PR TITLE
make rpython traceback involving the parse staticmethods more useful

### DIFF
--- a/rpylean/parser.py
+++ b/rpylean/parser.py
@@ -832,6 +832,9 @@ TOKEN_KINDS = {
     "#AX": Axiom,
 }
 
+for token, cls in TOKEN_KINDS.items():
+    cls.parse.func_name += "_" + cls.__name__
+
 def tokenize(line, lineno):
     tokens = []
     column = 0


### PR DESCRIPTION
right now the rpython tracebacks just show "parse_22", with this change you see the involved class name too