### PR TITLE
WIP feat: reject constructor fields in universes too high for the inductive [FIX 054_typeWithTooHighTypeField.mk.ndjson]

### DIFF
--- a/rpylean/objects.py
+++ b/rpylean/objects.py
@@ -121,6 +121,42 @@ class W_HeartbeatError(W_CheckError):
         )
 
 
+class W_UniverseTooHigh(W_CheckError):
+    """
+    A constructor field's type lives in a universe too high for the inductive.
+    """
+
+    def __init__(
+        self,
+        environment,
+        inductive_name,
+        constructor_name,
+        field_type,
+        field_level,
+        inductive_level,
+    ):
+        self.environment = environment
+        self.name = inductive_name
+        self.constructor_name = constructor_name
+        self.field_type = field_type
+        self.field_level = field_level
+        self.inductive_level = inductive_level
+
+    def str(self):
+        return (
+            "in %s:\n"
+            "constructor %s has field of type\n"
+            "  %s\n"
+            "which lives in universe %s, but the inductive is in universe %s"
+        ) % (
+            self.name.str(),
+            self.constructor_name.str(),
+            self.environment.pretty(self.field_type),
+            self.field_level.str(),
+            self.inductive_level.str(),
+        )
+
+
 class _Item(object):
     """
     A common type for all Lean items.
@@ -2465,14 +2501,43 @@ class W_Inductive(W_DeclarationKind):
         self.is_recursive = is_recursive
 
     def type_check(self, type, env):
+        # Strip all ForAlls (parameters and indices) to get the final Sort
         target = type
-        for depth in range(self.num_params):
-            if not isinstance(target, W_ForAll):
-                break
+        depth = 0
+        while isinstance(target, W_ForAll):
             target = target.body.instantiate(target.binder.fvar(), depth)
-        inferred_type = target.infer(env)
-        if not isinstance(inferred_type.whnf(env), W_Sort):
+            depth += 1
+        target_whnf = target.whnf(env)
+        if not isinstance(target_whnf, W_Sort):
+            inferred_type = type.infer(env).whnf(env)
             return W_NotASort(env, type, inferred_type=inferred_type, name=None)
+
+        inductive_level = target_whnf.level
+
+        # Check each constructor's field types for universe constraints
+        for ctor in self.constructors:
+            ctor_type = ctor.type
+            # Skip parameters
+            for _ in range(ctor.w_kind.num_params):
+                if isinstance(ctor_type, W_ForAll):
+                    ctor_type = ctor_type.body.instantiate(ctor_type.binder.fvar())
+
+            # Check each field (only num_fields ForAlls, not indices)
+            for _ in range(ctor.w_kind.num_fields):
+                if not isinstance(ctor_type, W_ForAll):
+                    break
+                field_type = ctor_type.binder.type
+                field_level = env.infer_sort_of(field_type)
+                if not field_level.leq(inductive_level):
+                    return W_UniverseTooHigh(
+                        environment=env,
+                        inductive_name=self.names[0],
+                        constructor_name=ctor.name,
+                        field_type=field_type,
+                        field_level=field_level,
+                        inductive_level=inductive_level,
+                    )
+                ctor_type = ctor_type.body.instantiate(ctor_type.binder.fvar())
 
     def delaborate(self, name_with_levels, type, constants):
         ctors = [


### PR DESCRIPTION
**Generated by claude with some direction**


## Why the Tutorial Test Failed

The arena test `054_typeWithTooHighTypeField.mk.ndjson` defines an inductive type that violates Lean's **predicativity constraint**:

```lean
inductive typeWithTooHighTypeField : Type where
  | mk : Type → typeWithTooHighTypeField
```

The problem is:
- The inductive `typeWithTooHighTypeField` lives in `Type` (= `Sort 1`, universe level 1)
- The constructor `mk` has a field of type `Type`
- But `Type : Type 1` (= `Sort 2`), meaning the field's type lives in universe level 2

Lean's kernel enforces that **constructor field types must live in a universe ≤ the inductive's universe**. This is the predicativity rule that prevents paradoxes like Girard's paradox. rpylean was not checking this constraint, so it incorrectly accepted the invalid inductive.

## References

From [The Secret Life of Inductive Types - Type Checking in Lean 4](https://ammkrn.github.io/type_checking_in_lean4/declarations/inductive.html):

> "For any non-parameter element of the constructor type's telescope, the element's inferred sort must be less than or equal to the inductive type's sort, or the inductive type being declared has to be a prop."

From [Inductive Types - Lean Language Reference](https://lean-lang.org/doc/reference/latest/The-Type-System/Inductive-Types/):

> "A larger universe is required for this type because **constructor parameters must be in universes that are smaller than the inductive type's universe**."

The [Lean Kernel Arena](https://arena.lean-lang.org/) provides test cases like `054_typeWithTooHighTypeField.mk.ndjson` to verify alternative kernel implementations handle these constraints correctly.

## Changes Made

### 1. New Error Class: `W_UniverseTooHigh` (`rpylean/objects.py:123-157`)


### 2. Updated `W_Inductive.type_check` (`rpylean/objects.py:2503-2540`)

Modified the type checking method with two key changes:

**a) Extract the inductive's universe level correctly:**

Strip ALL ForAlls (parameters AND indices) from the inductive's type to reach the final Sort, then extract its level:


**b) Check each constructor's field types:**

For each constructor:
1. Skip `num_params` ForAlls (parameters are shared with the inductive)
2. Check exactly `num_fields` ForAlls (these are the actual data fields, not indices)
3. For each field, verify `field_level.leq(inductive_level)`