### PR TITLE
fix: add defeq assertion to infer app

### DIFF
--- a/rpylean/objects.py
+++ b/rpylean/objects.py
@@ -1400,8 +1400,9 @@ class W_LitStr(W_Expr):
     def build_str_expr(self, env):
         if len(self.val) > 5:
             print("Building large str expr for %s" % self.val[:10])
-        cons = Name(["List", "cons"]).const([W_LEVEL_ZERO])
-        expr = Name(["List", "nil"]).const([W_LEVEL_ZERO])
+        Char = Name.simple("Char").const()
+        cons = Name(["List", "cons"]).const([W_LEVEL_ZERO]).app(Char)
+        expr = Name(["List", "nil"]).const([W_LEVEL_ZERO]).app(Char)
         for i in range(len(self.val) - 1, -1, -1):
             char_expr = Name(["Char", "ofNat"]).app(W_LitNat.char(self.val[i]))
             expr = cons.app(char_expr, expr)
@@ -2689,7 +2690,8 @@ class W_App(W_Expr):
             raise RuntimeError(
                 "W_App.infer: expected function type, got %s" % type(fn_type)
             )
-        assert env.def_eq(fn_type.binder.type, self.arg.infer(env))
+        if not env.def_eq(fn_type.binder.type, self.arg.infer(env)):
+            raise W_TypeError(env, self.arg, fn_type.binder.type)
         body_type = fn_type.body.instantiate(self.arg)
         return body_type
 

--- a/rpylean/objects.py
+++ b/rpylean/objects.py
@@ -2689,6 +2689,7 @@ class W_App(W_Expr):
             raise RuntimeError(
                 "W_App.infer: expected function type, got %s" % type(fn_type)
             )
+        assert env.def_eq(fn_type.binder.type, self.arg.infer(env))
         body_type = fn_type.body.instantiate(self.arg)
         return body_type
 

--- a/tests/test_def_eq.py
+++ b/tests/test_def_eq.py
@@ -128,8 +128,8 @@ class TestLitStr(object):
 
         o = ofNat.app(W_LitNat.char("o"))
         k = ofNat.app(W_LitNat.char("k"))
-        nil = Name(["List", "nil"]).const([W_LEVEL_ZERO])
-        cons = Name(["List", "cons"]).const([W_LEVEL_ZERO])
+        nil = Name(["List", "nil"]).const([W_LEVEL_ZERO]).app(Char.const())
+        cons = Name(["List", "cons"]).const([W_LEVEL_ZERO]).app(Char.const())
         o_k = cons.app(o, cons.app(k, nil))
         assert env.def_eq(W_LitStr("ok"), String_mk.app(o_k))
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -736,18 +736,19 @@ class TestInvalidDeclaration(object):
         ctor_type = forall(a.binder(type=PROP))(Foo.const())
         mk_decl = mk.constructor(type=ctor_type, num_fields=1)
         Foo_decl = Foo.inductive(type=TYPE, constructors=[mk_decl])
+        p = Name.simple("p").axiom(type=PROP)
         bad = Name.simple("bad").definition(
             type=PROP,
-            value=Foo.proj(3, mk.app(PROP)),
+            value=Foo.proj(3, mk.app(p.const())),
         )
-        env = Environment.having([Foo_decl, mk_decl, bad])
+        env = Environment.having([Foo_decl, mk_decl, p, bad])
         errors = type_check(env=env)
         assert len(errors) == 1
         assert errors[0].as_diagnostic().format_with(FORMAT_PLAIN) == dedent(
             """\
             def bad : Prop :=
-              (Foo.mk Prop).3
-              ^^^^^^^^^^^^^^^
+              (Foo.mk p).3
+              ^^^^^^^^^^^^
               Foo has only 2 fields""",
         )
 
@@ -808,6 +809,59 @@ class TestInvalidDeclaration(object):
               Bar.0
               ^^^^^
               unknown structure Foo""",
+        )
+
+    def test_proj_of_prop_with_ill_typed_ctor_arg_rejected(self):
+        """
+        ``(Wrapper.mk True.intro).p`` is a "proof" of ``False`` only if the
+        kernel skips checking ``Wrapper.mk``'s argument types: ``mk`` expects
+        a ``False``, so passing ``True.intro : True`` must be rejected during
+        application inference, before the projection ever reads back ``False``.
+
+        See lean-kernel-arena's ``tests/proj-of-prop.lean``.
+        """
+        Wrapper = Name.simple("Wrapper")
+        wrapper_mk = Wrapper.child("mk")
+        p = Name.simple("p")
+        True_ = Name.simple("True")
+        true_intro = True_.child("intro")
+        False_ = Name.simple("False")
+        bad = Name.simple("badFalse")
+
+        False_decl = False_.inductive(type=PROP, constructors=[])
+        true_intro_decl = true_intro.constructor(type=True_.const())
+        True_decl = True_.inductive(type=PROP, constructors=[true_intro_decl])
+        wrapper_mk_decl = wrapper_mk.constructor(
+            type=forall(p.binder(type=False_.const()))(Wrapper.const()),
+            num_fields=1,
+        )
+        Wrapper_decl = Wrapper.inductive(
+            type=PROP, constructors=[wrapper_mk_decl],
+        )
+        bad_decl = bad.theorem(
+            type=False_.const(),
+            value=Wrapper.proj(0, wrapper_mk.app(true_intro.const())),
+        )
+
+        env = Environment.having([
+            False_decl,
+            True_decl, true_intro_decl,
+            Wrapper_decl, wrapper_mk_decl,
+            bad_decl,
+        ])
+        errors = type_check(env=env)
+        assert len(errors) == 1
+        assert isinstance(errors[0], W_TypeError)
+        assert errors[0].expected_type == False_.const()
+        assert errors[0].inferred_type == True_.const()
+        assert errors[0].as_diagnostic().format_with(FORMAT_PLAIN) == dedent(
+            """\
+            theorem badFalse : False := (Wrapper.mk True.intro).p
+                                                    ^^^^^^^^^^
+                                                    has type
+                                                      True
+                                                    but is expected to have type
+                                                      False""",
         )
 
 

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -114,9 +114,9 @@ class TestProj(object):
         mk = Foo.child("mk")
         mk_decl = mk.constructor(type=forall(a.binder(type=NAT))(Foo.const()))
         Foo_decl = Foo.inductive(type=TYPE, constructors=[mk_decl])
-        x_decl = x.axiom(type=Foo.const())
-        env = Environment.having([Foo_decl, mk_decl, x_decl])
-        proj = Foo.proj(0, mk.app(NAT))
+        nat_decl = NAT.name.axiom(type=TYPE)
+        env = Environment.having([Foo_decl, mk_decl, nat_decl])
+        proj = Foo.proj(0, mk.app(W_LitNat.int(0)))
         inferred = proj.infer(env)
         assert inferred == NAT
 
@@ -126,8 +126,9 @@ class TestProj(object):
         ctor_type = forall(a.binder(type=NAT))(Foo.const())
         mk_decl = mk.constructor(type=ctor_type)
         Foo_decl = Foo.inductive(type=TYPE, constructors=[mk_decl])
-        env = Environment.having([Foo_decl, mk_decl])
-        proj = Foo.proj(1, mk.app(NAT))
+        nat_decl = NAT.name.axiom(type=TYPE)
+        env = Environment.having([Foo_decl, mk_decl, nat_decl])
+        proj = Foo.proj(1, mk.app(W_LitNat.int(0)))
         with pytest.raises(InvalidProjection) as e:
             proj.infer(env)
 
@@ -151,8 +152,9 @@ class TestProj(object):
         ctor_type = forall(a.binder(type=NAT))(Foo.const())
         mk_decl = mk.constructor(type=ctor_type)
         Foo_decl = Foo.inductive(type=TYPE, constructors=[mk_decl])
-        env = Environment.having([Foo_decl, mk_decl])
-        proj = Foo.proj(3, mk.app(NAT))
+        nat_decl = NAT.name.axiom(type=TYPE)
+        env = Environment.having([Foo_decl, mk_decl, nat_decl])
+        proj = Foo.proj(3, mk.app(W_LitNat.int(0)))
         with pytest.raises(InvalidProjection) as e:
             proj.infer(env)
 
@@ -174,8 +176,12 @@ class TestProj(object):
             )(T.const()),
         )
         T_decl = T.inductive(type=TYPE, constructors=[mk_decl])
-        env = Environment.having([T_decl, mk_decl])
-        struct_expr = mk.app(W_LitNat.int(5), W_LitNat.int(3))
+        nat_decl = NAT.name.axiom(type=TYPE)
+        Fin_decl = Fin.axiom(type=forall(x.binder(type=NAT))(TYPE))
+        fin5 = Name.simple("fin5")
+        fin5_decl = fin5.axiom(type=Fin.app(W_LitNat.int(5)))
+        env = Environment.having([T_decl, mk_decl, nat_decl, Fin_decl, fin5_decl])
+        struct_expr = mk.app(W_LitNat.int(5), fin5.const())
         proj = T.proj(1, struct_expr)
         assert proj.infer(env) == Fin.app(T.proj(0, struct_expr))
 
@@ -208,8 +214,9 @@ class TestProj(object):
         # Field type is Foo itself, which lives in Prop, so sort_of(Foo) = Prop.
         mk_decl = mk.constructor(type=forall(a.binder(type=Foo.const()))(Foo.const()))
         Foo_decl = Foo.inductive(type=PROP, constructors=[mk_decl])
-        env = Environment.having([Foo_decl, mk_decl])
-        proj = Foo.proj(0, mk.app(Foo.const()))
+        q = Name.simple("q").axiom(type=Foo.const())
+        env = Environment.having([Foo_decl, mk_decl, q])
+        proj = Foo.proj(0, mk.app(q.const()))
         assert proj.infer(env) == Foo.const()
 
     def test_prop_projection_of_non_prop_field_rejected(self):
@@ -220,8 +227,9 @@ class TestProj(object):
             type=forall(a.binder(type=Foo.const()), x.binder(type=TYPE))(Foo.const())
         )
         Foo_decl = Foo.inductive(type=PROP, constructors=[mk_decl])
-        env = Environment.having([Foo_decl, mk_decl])
-        proj = Foo.proj(1, mk.app(Foo.const(), TYPE))
+        q = Name.simple("q").axiom(type=Foo.const())
+        env = Environment.having([Foo_decl, mk_decl, q])
+        proj = Foo.proj(1, mk.app(q.const(), PROP))
         with pytest.raises(InvalidProjection) as e:
             proj.infer(env)
         assert (
@@ -240,8 +248,10 @@ class TestProj(object):
             type=forall(a.binder(type=TYPE), x.binder(type=Bar.app(b0)))(Foo.const())
         )
         Foo_decl = Foo.inductive(type=PROP, constructors=[mk_decl])
-        env = Environment.having([Foo_decl, mk_decl])
-        proj = Foo.proj(1, mk.app(TYPE, Bar.const()))
+        Bar_decl = Bar.axiom(type=forall(a.binder(type=TYPE))(TYPE))
+        b = Name.simple("b").axiom(type=Bar.app(PROP))
+        env = Environment.having([Foo_decl, mk_decl, Bar_decl, b])
+        proj = Foo.proj(1, mk.app(PROP, b.const()))
         with pytest.raises(InvalidProjection) as e:
             proj.infer(env)
         assert (


### PR DESCRIPTION
The infer method for function application needs (in some cases) to assert that the function's binder and the argument being applied have definitionally equal types.

This fixes the proj-of-prop test case, but from what I can tell rpylean doesn't use the `check` (or `infer_only` depending on what you want the bool to signal) flag, which makes certain assertions conditional (like this one). There is no soundness or completeness issue if these checks are always done, but you will take a performance hit, probably on the order of +50% run time.